### PR TITLE
Add a VSCode tip in the CSS reset section

### DIFF
--- a/docusaurus/docs/adding-css-reset.md
+++ b/docusaurus/docs/adding-css-reset.md
@@ -16,6 +16,8 @@ To start using it, add `@import-normalize;` anywhere in your CSS file(s). You on
 /* rest of app styles */
 ```
 
+> **Tip**: If you see an "_Unknown at rule @import-normalize css(unknownAtRules)_" warning in your VSCode editor, change `css.lint.unknownAtRules` to `ignore`.
+
 You can control which parts of [normalize.css] to use via your project's [browserslist].
 
 Results when [browserslist] is `last 3 versions`:


### PR DESCRIPTION
A warning kept popping up in my editor. Narrowed it down to https://github.com/Microsoft/vscode/issues/53175. Adding the suggestion as a tip.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
